### PR TITLE
Add ssl policy to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -20,3 +20,8 @@ output "sg_ids" {
     internet = var.internal ? null : aws_security_group.alb[0].id
   }
 }
+
+output "ssl_policy" {
+  description = "SSL Policy attached to loadbalancer"
+  value       = aws_lb_listener.tls.ssl_policy
+}


### PR DESCRIPTION
We need this policy in terraform-aws-eks which uses this module.

terraform-aws-eks creates Ingress object which should set annotation set
to the same value as we set here for LB.
