### PR TITLE
INFRA-2815: Add support for additional ports

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,28 @@ resource "aws_security_group" "alb" {
     protocol         = "tcp"
     ipv6_cidr_blocks = var.open_to_all ? ["::/0"] : data.cloudflare_ip_ranges.cloudflare.ipv6_cidr_blocks
   }
+
+  dynamic "ingress" {
+    for_each = var.additional_open_ports
+
+    content {
+      from_port        = ingress.value["port"]
+      to_port          = ingress.value["port"]
+      protocol         = ingress.value["protocol"]
+      cidr_blocks      = var.open_to_all ? ["0.0.0.0/0"] : data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks
+    }
+  }
+
+  dynamic "ingress" {
+    for_each = var.additional_open_ports
+
+    content {
+      from_port        = ingress.value["port"]
+      to_port          = ingress.value["port"]
+      protocol         = ingress.value["protocol"]
+      ipv6_cidr_blocks = var.open_to_all ? ["::/0"] : data.cloudflare_ip_ranges.cloudflare.ipv6_cidr_blocks
+    }
+  }
 }
 
 resource "aws_security_group" "alb_backend" {

--- a/variables.tf
+++ b/variables.tf
@@ -63,6 +63,15 @@ variable "backend_ingress_rules" {
   default = []
 }
 
+variable "additional_open_ports" {
+  description = "Additional ports accessible from the Internet for the ALB"
+  type = set(object({
+    port     = number
+    protocol = optional(string, "tcp")
+  }))
+  default = []
+}
+
 variable "tls_listener_version" {
   description = "Minimum TLS version served by TLS listener"
   type        = string


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-2815/update-traefik-configuration-for-orb-eks-clusters-to-support-grpc
Tested (yes/no): no
Description/Why: 
![image](https://github.com/user-attachments/assets/90d755eb-1fb2-4c3d-8a18-f290c44dffd9)
