### PR TITLE
fix: correct override default rules to be used in nasted modules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -107,33 +107,7 @@ variable "waf_rules" {
     priority                                 = number
     managed_rule_group_statement_vendor_name = string
   }))
-  default = [
-    {
-      name                                     = "AWSManagedRulesCommonRuleSet"
-      priority                                 = 0
-      managed_rule_group_statement_vendor_name = "AWS"
-    },
-    {
-      name                                     = "AWSManagedRulesKnownBadInputsRuleSet"
-      priority                                 = 1
-      managed_rule_group_statement_vendor_name = "AWS"
-    },
-    {
-      name                                     = "AWSManagedRulesAmazonIpReputationList"
-      priority                                 = 2
-      managed_rule_group_statement_vendor_name = "AWS"
-    },
-    {
-      name                                     = "AWSManagedRulesAnonymousIpList"
-      priority                                 = 3
-      managed_rule_group_statement_vendor_name = "AWS"
-    },
-    {
-      name                                     = "AWSManagedRulesSQLiRuleSet"
-      priority                                 = 4
-      managed_rule_group_statement_vendor_name = "AWS"
-    }
-  ]
+  default = []
 }
 
 variable "drop_invalid_header_fields" {

--- a/waf.tf
+++ b/waf.tf
@@ -1,3 +1,33 @@
+locals {
+  waf_rules = length(var.waf_rules) != 0 ? var.waf_rules : [
+    {
+      name                                     = "AWSManagedRulesCommonRuleSet"
+      priority                                 = 0
+      managed_rule_group_statement_vendor_name = "AWS"
+    },
+    {
+      name                                     = "AWSManagedRulesKnownBadInputsRuleSet"
+      priority                                 = 1
+      managed_rule_group_statement_vendor_name = "AWS"
+    },
+    {
+      name                                     = "AWSManagedRulesAmazonIpReputationList"
+      priority                                 = 2
+      managed_rule_group_statement_vendor_name = "AWS"
+    },
+    {
+      name                                     = "AWSManagedRulesAnonymousIpList"
+      priority                                 = 3
+      managed_rule_group_statement_vendor_name = "AWS"
+    },
+    {
+      name                                     = "AWSManagedRulesSQLiRuleSet"
+      priority                                 = 4
+      managed_rule_group_statement_vendor_name = "AWS"
+    }
+  ]
+}
+
 resource "aws_wafv2_web_acl" "alb_waf" {
   count = var.waf_enabled ? 1 : 0
   name  = format("%s-waf", local.name)
@@ -12,7 +42,7 @@ resource "aws_wafv2_web_acl" "alb_waf" {
   }
 
   dynamic "rule" {
-    for_each = toset(var.waf_rules)
+    for_each = toset(local.waf_rules)
     content {
       name     = rule.value.name
       priority = rule.value.priority


### PR DESCRIPTION
Issuer: @jozwior 
Tested: yes (local tf console)
Description: In old setup there wasn't way to use override default values in nested modules