### PR TITLE
[INFRA-3280] Don't add access_logs block when S3 bucket is empty

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,10 +97,13 @@ resource "aws_lb" "alb" {
   idle_timeout                     = var.idle_timeout
   drop_invalid_header_fields       = var.drop_invalid_header_fields
 
-  access_logs {
-    enabled = var.s3_logs_bucket_id != null ? true : false
-    bucket  = var.s3_logs_bucket_id
-    prefix  = var.cluster_name
+  dynamic "access_logs" {
+    for_each = length(var.s3_logs_bucket_id) > 0 ? [1] : [] # Create block only if bucket name is set
+    content {
+      enabled = true
+      bucket  = var.s3_logs_bucket_id
+      prefix  = var.cluster_name
+    }
   }
 
   tags = {


### PR DESCRIPTION
https://linear.app/worldcoin/issue/INFRA-3280/[terraform-aws-alb]-vars3-logs-bucket-id-cannot-be-null

Tested (use ALB module with those changes in EKS module resulted in not diff, so should be non breaking): https://tfe.worldcoin.dev/app/TFH/internal-tools-dev-us-east-1/runs/run-4ryA9uEaeqs6Bds3

We mostly use `terrafomr-aws-alb` inside `terraform-aws-eks`. In EKs module we validate if the variable for S3 logs bucket is set - so no issue, but in case `terraform-aws-alb` is used on it's own, allowing empty S3 bucket breaks the module (even though it being empty is acceptable), because for `access_logs` block to be present (even when `enabled` is set to `false`) a parameter for bucket must be set. Making this block dynamic makes more sense - no bucket = no block, bucket present = block exists and is enabled.
