### PR TITLE
[INFRA-4056] Add default listener ARN to outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,3 +25,8 @@ output "ssl_policy" {
   description = "SSL Policy attached to loadbalancer"
   value       = aws_lb_listener.tls.ssl_policy
 }
+
+output "listener_arn" {
+  description = "The ARN of the ALB default listener."
+  value       = aws_lb_listener.tls.arn
+}


### PR DESCRIPTION
I need this to be able to reference listener created by module, when adding external resource `aws_lb_listener_rule` for routing.
