### PR TITLE
Dont block module updates

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
 
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.10"
+      version = ">= 4.10"
     }
   }
 


### PR DESCRIPTION
Requestor/Issue: me
Tested (yes/no): yes
Description/Why: 

Dont block module updates with major lock

We should never use ~> in modules as it makes major upgrades more complex