### PR TITLE
feat: enable drop_invalid_header_fields=true by default

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "open_to_all" {
 variable "drop_invalid_header_fields" {
   description = "Drop invalid header fields"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "enable_deletion_protection" {


### PR DESCRIPTION
## Background

During review of [terraform-aws-alb PR #66](https://github.com/worldcoin/terraform-aws-alb/pull/66) (tfsec → trivy migration), a Trivy finding was raised for [AVD-AWS-0052](https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0052/) — ALB not configured to drop invalid headers.

## What changed

Updated the `drop_invalid_header_fields` variable default from `false` to `true`.

## Why

Passing unknown or invalid HTTP headers through to backend targets is a security risk. Enabling `drop_invalid_header_fields` removes non-standard headers at the load balancer level, reducing the attack surface.

See: https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0052/#Terraform

## Deployment approach

Apply to dev/stage environments first, verify no issues, then roll out to prod.

## References

- Linear: https://linear.app/worldcoin/issue/INFRA-6097
- [AVD-AWS-0052](https://avd.aquasec.com/misconfig/aws/elb/avd-aws-0052/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)