### PR TITLE
INFRA-6690: Add trust store ARN output for Gateway API mTLS integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,5 +128,6 @@ No modules.
 | <a name="output_listener_arn"></a> [listener\_arn](#output\_listener\_arn) | The ARN of the ALB default listener. |
 | <a name="output_sg_ids"></a> [sg\_ids](#output\_sg\_ids) | Security Group attached to loadbalancer |
 | <a name="output_ssl_policy"></a> [ssl\_policy](#output\_ssl\_policy) | SSL Policy attached to loadbalancer |
+| <a name="output_trust_store_arn"></a> [trust\_store\_arn](#output\_trust\_store\_arn) | The ARN of the mTLS trust store. |
 | <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | The zone ID of the NLB. |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,3 +30,8 @@ output "listener_arn" {
   description = "The ARN of the ALB default listener."
   value       = var.create_default_listener ? aws_lb_listener.tls[0].arn : null
 }
+
+output "trust_store_arn" {
+  description = "The ARN of the mTLS trust store."
+  value       = var.mtls_enabled ? aws_lb_trust_store.root_ca[0].arn : null
+}


### PR DESCRIPTION
Requestor/Issue: https://linear.app/worldcoin/issue/INFRA-6690/enable-mtls-for-external-alb-default-listener
Tested (yes/no): yes (tf plan)
Description/Why: Trust store was already created when `mtls_enabled = true`, but the ARN wasn't exposed — needed by `terraform-aws-eks` to configure `mutualAuthentication` in `LoadBalancerConfiguration` listener configs
