### PR TITLE
feat: add enable_cross_zone_load_balancing variable (INFRA-6671)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "aws_lb" "alb" {
     aws_security_group.alb_backend.id
   ])
 
-  enable_cross_zone_load_balancing = true
+  enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing
   enable_deletion_protection       = var.enable_deletion_protection
   idle_timeout                     = var.idle_timeout
   #trivy:ignore:AWS-0052

--- a/variables.tf
+++ b/variables.tf
@@ -111,6 +111,12 @@ variable "enable_deletion_protection" {
   default     = true
 }
 
+variable "enable_cross_zone_load_balancing" {
+  description = "If true, cross-zone load balancing is enabled at the load-balancer level. AWS always enables cross-zone for Application Load Balancers at the LB level; this attribute on `aws_lb` is provided for API parity and may be ignored by AWS. To actually disable cross-zone for an ALB, set `load_balancing_cross_zone_enabled = false` at the target-group level (separate concern; not handled by this module). Default true matches AWS behavior."
+  type        = bool
+  default     = true
+}
+
 variable "mtls_enabled" {
   description = "Enable mutual TLS (mTLS) on the ALB TLS listener"
   type        = bool


### PR DESCRIPTION
## Summary

Expose the \`aws_lb\` resource's \`enable_cross_zone_load_balancing\` attribute as a module input. Default \`true\` — matches AWS' ALB behavior (ALBs always have cross-zone enabled at the LB level).

\`\`\`hcl
variable \"enable_cross_zone_load_balancing\" {
  type    = bool
  default = true
}
\`\`\`

## Why

Sibling change to [terraform-aws-nlb #70](https://github.com/worldcoin/terraform-aws-nlb/pull/70), filed as part of [INFRA-6671](https://linear.app/worldcoin/issue/INFRA-6671). The two modules now share an identical interface for cross-zone control, so the downstream EKS module can thread a single variable through to either LB type.

## ALB-specific caveat

> Per AWS docs, Application Load Balancers **always have cross-zone load balancing enabled** at the LB level, and the \`enable_cross_zone_load_balancing\` attribute is **ignored** for ALBs.

For an ALB the practical way to disable cross-zone is **at the target-group level** via \`load_balancing_cross_zone_enabled\` on the \`aws_lb_target_group\` resource — which is a separate concern this module doesn't own.

The variable on this module exists for:
1. **API parity** with terraform-aws-nlb so callers can use the same wiring
2. **Future-proofing** in case AWS later allows LB-level disable on ALBs

If a caller sets \`false\`, AWS will silently keep cross-zone on. That's the AWS behavior, not a module bug.

## Changes

- \`variables.tf\`: new \`enable_cross_zone_load_balancing\` (bool, default \`true\`)
- \`main.tf\`: \`enable_cross_zone_load_balancing = var.enable_cross_zone_load_balancing\` (was hardcoded \`true\`)

## Test plan

- [x] \`terraform plan\` with no variables → no diff
- [x] \`terraform plan\` with \`enable_cross_zone_load_balancing = false\` → terraform shows the attribute would change to \`false\`, AWS will ignore it
- [ ] Released version consumed by [terraform-aws-eks](https://github.com/worldcoin/terraform-aws-eks) PR (companion)